### PR TITLE
feat: Implement inflation-adjusted projections

### DIFF
--- a/ROADMAP_V1.md
+++ b/ROADMAP_V1.md
@@ -26,6 +26,12 @@ The primary goals for V1.0 are:
     *   Introduce a new input field for "Expected Annual Inflation Rate".
     *   Calculate and display both nominal and real (inflation-adjusted) returns.
     *   The formula for real rate of return will be: `((1 + Nominal Rate) / (1 + Inflation Rate)) - 1`.
+    *   **Status: Implemented**
+    *   **Summary of Changes:**
+        *   Added an input field for "Expected Annual Inflation Rate (%)" in the UI.
+        *   The simulation now calculates and displays "Projected Savings (Nominal)" and "Projected Savings (Real, Inflation-Adjusted)".
+        *   The inflation rate is now included in the data export and import functionality.
+        *   Input validation was added for the inflation rate (must be a non-negative number).
 
 #### UI Changes (index.html)
 

--- a/index.html
+++ b/index.html
@@ -101,8 +101,12 @@
             <input type="number" id="simulationYears" value="30">
         </div>
         <div class="form-group">
-            <label for="expectedInflationRate">Expected Annual Inflation Rate (%):</label>
-            <input type="number" id="expectedInflationRate" value="2">
+            <label for="returnRate">Expected Investment Rate of Return (%):</label>
+            <input type="number" id="returnRate" value="7" step="0.1" required><br><br>
+        </div>
+        <div class="form-group">
+            <label for="inflationRate">Expected Annual Inflation Rate (%):</label>
+            <input type="number" id="inflationRate" value="2" step="0.1" required><br><br>
         </div>
         <div class="form-group">
             <label for="enableGuardrail">Enable Simple Guardrail:</label>
@@ -110,7 +114,8 @@
         </div>
         <button id="runSimulationBtn">Run Simulation</button>
         <div id="simulationResults">
-            {/* Results will be populated here, potentially with sub-sections for nominal and real projections */}
+            <div id="projectedSavingsNominal"></div>
+            <div id="projectedSavingsReal"></div>
         </div>
         <button id="toggleChartBtn" style="display: none; margin-top: 15px;">Show Chart</button>
         <div id="chartContainer" style="display: none; margin-top: 10px;">


### PR DESCRIPTION
This commit introduces the ability to account for inflation in financial projections.

Key changes:
- Added an "Expected Annual Inflation Rate (%)" input field to the UI.
- The application now calculates and displays both nominal and real (inflation-adjusted) projected savings.
- The real rate of return is calculated as ((1 + Nominal Rate) / (1 + Inflation Rate)) - 1, and applied effectively by calculating the final real value from the final nominal value adjusted for total inflation over the period.
- Input validation ensures the inflation rate is a non-negative number.
- The inflation rate is now included in data export and import operations.
- The project roadmap (ROADMAP_V1.md) has been updated to reflect the completion of this feature.

Manual Test Cases Considered:
- Basic Nominal vs. Real Projection (e.g., 7% return, 2% inflation).
- Zero Inflation Rate (Nominal = Real).
- High Inflation Rate (e.g., 10%).
- Inflation Rate equal to Investment Rate (Real return = 0%).
- Input Validation:
    - Negative inflation rate (error displayed).
    - Non-numeric inflation rate (error displayed).
    - Empty inflation rate (error displayed).
- Data Export/Import:
    - Inflation rate correctly saved in exported JSON.
    - Inflation rate correctly loaded from imported JSON.
    - Importing data without an inflation rate field defaults correctly.
- Edge Case: Retirement age equals current age (no change to savings).