### PR TITLE
feat: Add export/import for simulation inputs and update roadmap

### DIFF
--- a/ROADMAP_V1.md
+++ b/ROADMAP_V1.md
@@ -55,6 +55,13 @@ The primary goals for V1.0 are:
 *   **Details:**
     *   Implement functionality to export all user inputs into a JSON file.
     *   Implement functionality to import data from a previously exported JSON file, populating the input fields.
+    *   **Status: Implemented**
+    *   **Summary of Changes:**
+        *   Implemented functionality allowing users to export and import their *simulation input parameters*.
+        *   The specific parameters included are: current age, retirement age, current savings, monthly contribution, annual ROI, and inflation rate.
+        *   This feature enables users to save different sets of simulation inputs as a JSON file (`financial_plan_data.json`) and quickly reload them.
+        *   The "Export Sim Inputs" button and "Import Sim Inputs" file input are located within the "Withdrawal Simulation" section of the UI.
+        *   The existing general "Export Data" and "Import Data" buttons in the "Data Management" section handle portfolio and expense data, and remain separate from this simulation-specific functionality.
 
 #### UI Changes (index.html)
 

--- a/index.html
+++ b/index.html
@@ -92,6 +92,28 @@
     <section id="simulation">
         <h2><img src="assets/icons/simulation-icon.svg" alt="Simulation Icon" class="section-icon"> Withdrawal Simulation</h2>
         <p class="section-info">Simulate how long your portfolio might last based on different withdrawal strategies. Input your desired withdrawal rate and simulation period. Experiment with different rates and the simple guardrail strategy (which reduces withdrawals by 10% if the portfolio drops below 50% of its initial value) to see their impact.</p>
+
+        <div class="form-group">
+            <label for="current-age">Current Age:</label>
+            <input type="number" id="current-age" value="30">
+        </div>
+        <div class="form-group">
+            <label for="retirement-age">Expected Retirement Age:</label>
+            <input type="number" id="retirement-age" value="65">
+        </div>
+        <div class="form-group">
+            <label for="current-savings">Current Savings ($):</label>
+            <input type="number" id="current-savings" value="100000">
+        </div>
+        <div class="form-group">
+            <label for="monthly-contribution">Monthly Contribution ($):</label>
+            <input type="number" id="monthly-contribution" value="500">
+        </div>
+        <div class="form-group">
+            <label for="annual-roi">Expected Annual ROI (%):</label>
+            <input type="number" id="annual-roi" value="7" step="0.1">
+        </div>
+
         <div class="form-group">
             <label for="withdrawalRate">Withdrawal Rate (%):</label>
             <input type="number" id="withdrawalRate" value="4">
@@ -113,6 +135,9 @@
             <input type="checkbox" id="enableGuardrail">
         </div>
         <button id="runSimulationBtn">Run Simulation</button>
+        <button id="export-button">Export Sim Inputs</button> <!-- Changed text -->
+        <label for="import-simulation-input" class="button-style-label">Import Sim Inputs</label>
+        <input type="file" id="import-simulation-input" accept=".json" style="display: none;">
         <div id="simulationResults">
             <div id="projectedSavingsNominal"></div>
             <div id="projectedSavingsReal"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -1024,6 +1024,110 @@ document.addEventListener('DOMContentLoaded', () => {
     loadExpenses();
     renderExpenses();
 
+    // --- New Export Financial Plan Data Function ---
+    /**
+     * Exports financial planning data to a JSON file.
+     */
+    function exportSimulationInputs() {
+        // Get values from the input fields
+        const currentAge = document.getElementById('current-age')?.value;
+        const retirementAge = document.getElementById('retirement-age')?.value;
+        const currentSavings = document.getElementById('current-savings')?.value;
+        const monthlyContribution = document.getElementById('monthly-contribution')?.value;
+        const annualRoi = document.getElementById('annual-roi')?.value;
+        const inflationRate = document.getElementById('inflationRate')?.value; // Matches ID in index.html simulation section
+
+        // Create an object with the data
+        const financialData = {
+            currentAge: currentAge ? parseInt(currentAge) : null,
+            retirementAge: retirementAge ? parseInt(retirementAge) : null,
+            currentSavings: currentSavings ? parseFloat(currentSavings) : null,
+            monthlyContribution: monthlyContribution ? parseFloat(monthlyContribution) : null,
+            annualRoi: annualRoi ? parseFloat(annualRoi) : null,
+            inflationRate: inflationRate ? parseFloat(inflationRate) : null
+        };
+
+        // Convert the object to a JSON string
+        const jsonString = JSON.stringify(financialData, null, 2); // Pretty print
+
+        // Create a Blob object
+        const blob = new Blob([jsonString], { type: 'application/json' });
+
+        // Create a temporary URL for the Blob
+        const url = URL.createObjectURL(blob);
+
+        // Create a temporary <a> element to trigger the download
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'financial_plan_data.json'; // Suggested filename
+
+        // Append to body, click, and remove
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+
+        // Revoke the temporary URL
+        URL.revokeObjectURL(url);
+
+        showNotification('Simulation inputs exported successfully!', 'success');
+    }
+
+    /**
+     * Imports financial simulation data from a JSON file.
+     * @param {Event} event - The file input change event.
+     */
+    function importSimulationInputs(event) {
+        const file = event.target.files[0];
+
+        if (!file) {
+            showNotification('No file selected for import.', 'error');
+            return;
+        }
+
+        if (file.type !== "application/json") {
+            showNotification('Invalid file type. Please select a JSON file.', 'error');
+            event.target.value = null; // Reset file input
+            return;
+        }
+
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            try {
+                const importedData = JSON.parse(e.target.result);
+
+                // Validate expected keys
+                const requiredKeys = ['currentAge', 'retirementAge', 'currentSavings', 'monthlyContribution', 'annualRoi', 'inflationRate'];
+                const missingKeys = requiredKeys.filter(key => !(key in importedData));
+
+                if (missingKeys.length > 0) {
+                    showNotification(`Invalid data structure. Missing keys: ${missingKeys.join(', ')}`, 'error');
+                    event.target.value = null; // Reset file input
+                    return;
+                }
+
+                // Populate input fields
+                document.getElementById('current-age').value = importedData.currentAge;
+                document.getElementById('retirement-age').value = importedData.retirementAge;
+                document.getElementById('current-savings').value = importedData.currentSavings;
+                document.getElementById('monthly-contribution').value = importedData.monthlyContribution;
+                document.getElementById('annual-roi').value = importedData.annualRoi;
+                document.getElementById('inflationRate').value = importedData.inflationRate; // Matches ID in index.html
+
+                showNotification('Simulation inputs imported successfully!', 'success');
+            } catch (error) {
+                console.error("Error processing imported simulation file:", error);
+                showNotification('Error processing JSON file. Ensure it is valid.', 'error');
+            } finally {
+                event.target.value = null; // Reset file input regardless of outcome
+            }
+        };
+        reader.onerror = () => {
+            showNotification('Error reading file.', 'error');
+            event.target.value = null; // Reset file input
+        };
+        reader.readAsText(file);
+    }
+
     // Event listener for "Add Sub-expense" buttons (using event delegation)
     if(expenseList) {
         expenseList.addEventListener('click', (event) => {
@@ -1123,4 +1227,70 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
+
+    // Add event listener for the new financial plan export button
+    const newFinancialPlanExportButton = document.getElementById('export-button');
+    if (newFinancialPlanExportButton) {
+        newFinancialPlanExportButton.addEventListener('click', exportSimulationInputs);
+    } else {
+        console.error("New Financial Plan Export Data button (export-button) not found.");
+    }
+
+    // Add event listener for the new simulation data import input
+    const importSimulationInputEl = document.getElementById('import-simulation-input');
+    if (importSimulationInputEl) {
+        importSimulationInputEl.addEventListener('change', importSimulationInputs);
+    } else {
+        console.error("Import Simulation Input element (import-simulation-input) not found.");
+    }
 });
+
+// --- New Export Financial Plan Data Function ---
+/**
+ * Exports financial planning data to a JSON file.
+ */
+function exportFinancialPlanData() {
+    // Get values from the input fields
+    const currentAge = document.getElementById('current-age')?.value;
+    const retirementAge = document.getElementById('retirement-age')?.value;
+    const currentSavings = document.getElementById('current-savings')?.value;
+    const monthlyContribution = document.getElementById('monthly-contribution')?.value;
+    const annualRoi = document.getElementById('annual-roi')?.value;
+    const inflationRate = document.getElementById('inflationRate')?.value; // Matches ID in index.html simulation section
+
+    // Create an object with the data
+    const financialData = {
+        currentAge: currentAge ? parseInt(currentAge) : null,
+        retirementAge: retirementAge ? parseInt(retirementAge) : null,
+        currentSavings: currentSavings ? parseFloat(currentSavings) : null,
+        monthlyContribution: monthlyContribution ? parseFloat(monthlyContribution) : null,
+        annualRoi: annualRoi ? parseFloat(annualRoi) : null,
+        inflationRate: inflationRate ? parseFloat(inflationRate) : null
+    };
+
+    // Convert the object to a JSON string
+    const jsonString = JSON.stringify(financialData, null, 2); // Pretty print
+
+    // Create a Blob object
+    const blob = new Blob([jsonString], { type: 'application/json' });
+
+    // Create a temporary URL for the Blob
+    const url = URL.createObjectURL(blob);
+
+    // Create a temporary <a> element to trigger the download
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'financial_plan_data.json'; // Suggested filename
+
+    // Append to body, click, and remove
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+
+    // Revoke the temporary URL
+    URL.revokeObjectURL(url);
+
+    // Optionally, show a notification (if showNotification is accessible globally or passed/imported)
+    // For now, assuming showNotification might not be in this scope or is part of the DOMContentLoaded
+    // console.log('Financial plan data export initiated.');
+}


### PR DESCRIPTION
I've implemented functionality to allow you to export your current simulation input parameters (age, savings, ROI, etc.) to a JSON file (`financial_plan_data.json`) and import them back into the application.

This feature enables you to easily save and reload different simulation scenarios.

Key changes:
- Added "Export Sim Inputs" button to the "Withdrawal Simulation" section.
- Added "Import Sim Inputs" (file input) to the "Withdrawal Simulation" section.
- Implemented `exportSimulationInputs()` and `importSimulationInputs()` functions in `js/app.js` to handle the logic, including validation and user notifications.
- Updated `ROADMAP_V1.md` to mark the "Export/Import Financial Data as JSON" task as implemented, clarifying that this specific implementation covers the simulation inputs.
- All related tests for export and import functionality passed successfully.