### PR TITLE
Refactor: Remove redundant inputs from simulation

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,16 +102,8 @@
             <input type="number" id="retirement-age" value="65">
         </div>
         <div class="form-group">
-            <label for="current-savings">Current Savings ($):</label>
-            <input type="number" id="current-savings" value="100000">
-        </div>
-        <div class="form-group">
             <label for="monthly-contribution">Monthly Contribution ($):</label>
             <input type="number" id="monthly-contribution" value="500">
-        </div>
-        <div class="form-group">
-            <label for="annual-roi">Expected Annual ROI (%):</label>
-            <input type="number" id="annual-roi" value="7" step="0.1">
         </div>
 
         <div class="form-group">

--- a/js/app.js
+++ b/js/app.js
@@ -1034,7 +1034,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const retirementAge = document.getElementById('retirement-age')?.value;
         const currentSavings = document.getElementById('current-savings')?.value;
         const monthlyContribution = document.getElementById('monthly-contribution')?.value;
-        const annualRoi = document.getElementById('annual-roi')?.value;
+        const annualRoi = document.getElementById('returnRate')?.value; // Changed from 'annual-roi'
         const inflationRate = document.getElementById('inflationRate')?.value; // Matches ID in index.html simulation section
 
         // Create an object with the data
@@ -1043,7 +1043,7 @@ document.addEventListener('DOMContentLoaded', () => {
             retirementAge: retirementAge ? parseInt(retirementAge) : null,
             currentSavings: currentSavings ? parseFloat(currentSavings) : null,
             monthlyContribution: monthlyContribution ? parseFloat(monthlyContribution) : null,
-            annualRoi: annualRoi ? parseFloat(annualRoi) : null,
+            returnRate: annualRoi ? parseFloat(annualRoi) : null, // Changed key from annualRoi
             inflationRate: inflationRate ? parseFloat(inflationRate) : null
         };
 
@@ -1096,8 +1096,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 const importedData = JSON.parse(e.target.result);
 
                 // Validate expected keys
-                const requiredKeys = ['currentAge', 'retirementAge', 'currentSavings', 'monthlyContribution', 'annualRoi', 'inflationRate'];
-                const missingKeys = requiredKeys.filter(key => !(key in importedData));
+                // currentSavings is removed, annualRoi is replaced by returnRate
+                const requiredKeys = ['currentAge', 'retirementAge', 'monthlyContribution', 'returnRate', 'inflationRate'];
+                const missingKeys = requiredKeys.filter(key => {
+                    if (key === 'returnRate') {
+                        return !(importedData.hasOwnProperty('returnRate') || importedData.hasOwnProperty('annualRoi'));
+                    }
+                    return !importedData.hasOwnProperty(key);
+                });
 
                 if (missingKeys.length > 0) {
                     showNotification(`Invalid data structure. Missing keys: ${missingKeys.join(', ')}`, 'error');
@@ -1108,9 +1114,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Populate input fields
                 document.getElementById('current-age').value = importedData.currentAge;
                 document.getElementById('retirement-age').value = importedData.retirementAge;
-                document.getElementById('current-savings').value = importedData.currentSavings;
+                // current-savings line is now fully removed
                 document.getElementById('monthly-contribution').value = importedData.monthlyContribution;
-                document.getElementById('annual-roi').value = importedData.annualRoi;
+                // Use returnRate key, fallback to annualRoi for backward compatibility
+                document.getElementById('returnRate').value = importedData.returnRate || importedData.annualRoi;
                 document.getElementById('inflationRate').value = importedData.inflationRate; // Matches ID in index.html
 
                 showNotification('Simulation inputs imported successfully!', 'success');
@@ -1244,53 +1251,3 @@ document.addEventListener('DOMContentLoaded', () => {
         console.error("Import Simulation Input element (import-simulation-input) not found.");
     }
 });
-
-// --- New Export Financial Plan Data Function ---
-/**
- * Exports financial planning data to a JSON file.
- */
-function exportFinancialPlanData() {
-    // Get values from the input fields
-    const currentAge = document.getElementById('current-age')?.value;
-    const retirementAge = document.getElementById('retirement-age')?.value;
-    const currentSavings = document.getElementById('current-savings')?.value;
-    const monthlyContribution = document.getElementById('monthly-contribution')?.value;
-    const annualRoi = document.getElementById('annual-roi')?.value;
-    const inflationRate = document.getElementById('inflationRate')?.value; // Matches ID in index.html simulation section
-
-    // Create an object with the data
-    const financialData = {
-        currentAge: currentAge ? parseInt(currentAge) : null,
-        retirementAge: retirementAge ? parseInt(retirementAge) : null,
-        currentSavings: currentSavings ? parseFloat(currentSavings) : null,
-        monthlyContribution: monthlyContribution ? parseFloat(monthlyContribution) : null,
-        annualRoi: annualRoi ? parseFloat(annualRoi) : null,
-        inflationRate: inflationRate ? parseFloat(inflationRate) : null
-    };
-
-    // Convert the object to a JSON string
-    const jsonString = JSON.stringify(financialData, null, 2); // Pretty print
-
-    // Create a Blob object
-    const blob = new Blob([jsonString], { type: 'application/json' });
-
-    // Create a temporary URL for the Blob
-    const url = URL.createObjectURL(blob);
-
-    // Create a temporary <a> element to trigger the download
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'financial_plan_data.json'; // Suggested filename
-
-    // Append to body, click, and remove
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-
-    // Revoke the temporary URL
-    URL.revokeObjectURL(url);
-
-    // Optionally, show a notification (if showNotification is accessible globally or passed/imported)
-    // For now, assuming showNotification might not be in this scope or is part of the DOMContentLoaded
-    // console.log('Financial plan data export initiated.');
-}


### PR DESCRIPTION
I've removed redundant input fields from the withdrawal simulation section to streamline your experience and infer data where possible.

Key changes:
- Removed "Current Savings ($)" input field. The simulation now consistently uses the "Total Portfolio Value" calculated from the Portfolio Tracking section as the initial savings.
- Removed "Expected Annual ROI (%)" input field. The simulation and "Export/Import Sim Inputs" feature now consistently use the "Expected Investment Rate of Return (%)" input field (ID: `returnRate`).
- Updated "Export/Import Sim Inputs" functionality:
    - Exported JSON now uses the key `returnRate` for the investment return.
    - Exported JSON now includes `currentSavings: null` as the input field was removed.
    - Import functionality is backward compatible: it can read `annualRoi` from older JSON files and populate the `returnRate` field.
    - Import functionality gracefully ignores `currentSavings` from older JSON files.
- Removed a duplicate `exportFinancialPlanData` JavaScript function.

These changes ensure that the simulation inputs are more concise, data is sourced consistently, and there is no duplication of information entry for you.