### PR TITLE
Add real value dataset to simulation chart

### DIFF
--- a/ROADMAP_V1.md
+++ b/ROADMAP_V1.md
@@ -92,6 +92,11 @@ The primary goals for V1.0 are:
     *   Implement a notification system for actions like successful data export/import or input errors.
     *   Improve the clarity of labels, instructions, and results display.
     *   Integrate an optional chart to visualize the projected savings over time.
+    *   **Status: Implemented**
+    *   **Summary of Changes:**
+        *   The chart now renders both nominal and real (inflation-adjusted) portfolio trajectories so users can directly compare purchasing power against raw balances.
+        *   Chart tooltips present currency values with consistent precision, improving readability when comparing datasets.
+        *   Simulation logic now correctly reads the inflation rate input, ensuring projections and the real-value series stay synchronized with the UI field.
 
 #### UI Changes (index.html)
 


### PR DESCRIPTION
## Summary
- render both nominal and inflation-adjusted balances in the withdrawal simulation chart for side-by-side comparison
- ensure the simulation reads the existing inflation rate input so calculations and charts stay in sync
- polish chart tooltips to show currency values with consistent precision

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caa0bce9008329a9ae3af986b0dc22