### PR TITLE
Add Monte Carlo simulation with auto-run triggers

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
             <div id="simulationResults">
                 <div id="projectedSavingsNominal" role="status" aria-live="polite"></div>
                 <div id="projectedSavingsReal" role="status" aria-live="polite"></div>
+                <div id="monteCarloResults" role="status" aria-live="polite"></div>
             </div>
             <button id="toggleChartBtn" aria-expanded="false" aria-controls="chartContainer">Show Chart</button>
             <div id="chartContainer" role="region" aria-live="polite" aria-label="Simulation results chart" hidden>


### PR DESCRIPTION
## Summary
- add Monte Carlo simulation helpers to model variable annual returns and summarise results
- surface Monte Carlo insights in the withdrawal section, using expenses when available
- automatically re-run deterministic and Monte Carlo simulations when portfolio or expense data changes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d56333c21c832994162a0bf67a2b76